### PR TITLE
Fix line height

### DIFF
--- a/resources/tanne.xml
+++ b/resources/tanne.xml
@@ -7,7 +7,7 @@
         <property name="originalScheme">Darcula</property>
     </metaInfo>
     <option name="FONT_SCALE" value="1.0"/>
-    <option name="LINE_SPACING" value="1.5"/>
+    <option name="LINE_SPACING" value="1.0"/>
     <font>
         <option name="EDITOR_FONT_NAME" value="Fira Code"/>
         <option name="EDITOR_FONT_SIZE" value="14"/>


### PR DESCRIPTION
Line height in code fonts should never be more than 1.0, it breaks the console and other text features that rely on monospaced text being 1:1 on the y axis